### PR TITLE
Make some noise for the keepassxc-cryptomator plug-in, if you like

### DIFF
--- a/source/desktop/accessing-vaults.rst
+++ b/source/desktop/accessing-vaults.rst
@@ -20,7 +20,7 @@ You will then be prompted for your vault's password:
 
 .. note::
 
-    By checking the "Save Password" checkbox, the password will be stored in your operating system's keychain.
+    By checking the "Save Password" checkbox, the password will be stored in your operating system's keychain. There is also a `plug\-in <https://plugin.purejava.org>`_ for Cryptomator available, that allows to store Cryptomator vault passwords in a KeePassXC database.
 
 .. warning::
 


### PR DESCRIPTION
This adds a reference to the Cryptomator plug-in web page to a note on the `Accessing Vaults` page.

<img width="692" alt="Bildschirmfoto 2022-09-10 um 07 57 14" src="https://user-images.githubusercontent.com/1822238/189471388-fdab31d4-d16b-47dd-a372-ed4a97c2ac2d.png">

I'd like the addition, but it's your choice and I am not disappointed, if you decide against the change.