### PR TITLE
updated Linux FUSE requirements

### DIFF
--- a/source/desktop/volume-type.rst
+++ b/source/desktop/volume-type.rst
@@ -177,7 +177,7 @@ Linux based OS
 FUSE
 ^^^^
 
-**Requirements:** Linux, ``libfuse3`` installed
+**Requirements:** Linux, ``libfuse3`` and/or ``fuse3`` installed
 
 FUSE on Linux works only if the `libfuse3` library is installed.
 Luckily, `libfuse3` library comes pre-installed on all major Linux distributions.

--- a/source/desktop/volume-type.rst
+++ b/source/desktop/volume-type.rst
@@ -177,7 +177,7 @@ Linux based OS
 FUSE
 ^^^^
 
-**Requirements:** Linux, ``libfuse3`` and/or ``fuse3`` installed
+**Requirements:** Linux, ``fuse3`` installed
 
 FUSE on Linux works only if the `libfuse3` library is installed.
 Luckily, `libfuse3` library comes pre-installed on all major Linux distributions.

--- a/source/desktop/volume-type.rst
+++ b/source/desktop/volume-type.rst
@@ -180,7 +180,7 @@ FUSE
 **Requirements:** Linux, ``fuse3`` installed
 
 FUSE on Linux works only if the `fuse3` package is installed.
-Luckily, `fuse3` comes pre-installed on all major Linux distributions.
+Luckily, `fuse3` comes pre-installed on many Linux distributions.
 
 
 By default, unlocked vaults are mounted to `~/.local/share/Cryptomator/mnt`, but you can use custom mount options to change the path.

--- a/source/desktop/volume-type.rst
+++ b/source/desktop/volume-type.rst
@@ -179,8 +179,8 @@ FUSE
 
 **Requirements:** Linux, ``fuse3`` installed
 
-FUSE on Linux works only if the `libfuse3` library is installed.
-Luckily, `libfuse3` library comes pre-installed on all major Linux distributions.
+FUSE on Linux works only if the `fuse3` package is installed.
+Luckily, `fuse3` comes pre-installed on all major Linux distributions.
 
 
 By default, unlocked vaults are mounted to `~/.local/share/Cryptomator/mnt`, but you can use custom mount options to change the path.


### PR DESCRIPTION
in my experience on Debian 11 it was not enough to have just the libfuse3 Library installed, the fuse3 Package was needed as well to mount a Cryptomator Vault with FUSE, otherwise I got Java Errors on the CLI.