### PR TITLE
Correct documentation of AAD for file content encryption

### DIFF
--- a/source/security/vault.rst
+++ b/source/security/vault.rst
@@ -49,7 +49,7 @@ The cleartext is broken down into multiple chunks, each up to 32 KiB + 28 bytes 
 * up to 32 KiB encrypted payload using AES-GCM with the file content key, and
 * 16 bytes tag computed by GCM with the following AAD:
 
-    * chunk number as 32 bit big endian integer (to prevent undetected reordering),
+    * chunk number as 64 bit big endian integer (to prevent undetected reordering),
     * file header nonce (to bind this chunk to the file header),
 
 Afterwards, the encrypted chunks are joined preserving the order of the cleartext chunks.


### PR DESCRIPTION
The documentation at https://docs.cryptomator.org/en/latest/security/architecture/ currently states:

> The cleartext is broken down into multiple chunks, each up to 32 KiB + 28 bytes consisting of:
> * 12 bytes nonce,
> * up to 32 KiB encrypted payload using AES-GCM with the file content key, and
> * 16 bytes tag computed by GCM with the following AAD:
>     * chunk number as **32 bit** big endian integer (to prevent undetected reordering),
>     * file header nonce (to bind this chunk to the file header),

However, as per [FileContentCryptorImpl (line 155)](https://github.com/cryptomator/cryptolib/blob/75c56b7d84563249248bfc0933545928a2d62f3f/src/main/java/org/cryptomator/cryptolib/v2/FileContentCryptorImpl.java#L155C30-L155C51), the chunk number is actually packed into `Long.SIZE` bits, which is 64 bits, not 32.

This pull request corrects the documentation.