### PR TITLE
Add note for `versionMac` calculation details

### DIFF
--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -139,6 +139,10 @@ The wrapped keys and the parameters needed to derive the KEK are then stored as 
 }
 ```
 
+:::note
+When calculating the `versionMac`, the `version` value must be converted to a 32-bit unsigned integer and then encoded as a 4-byte big-endian representation before computing the HMAC-SHA256, regardless of the system's native byte order.
+:::
+
 When unlocking a vault the KEK is used to unwrap (i.e. decrypt) the stored masterkeys.
 
 <WhiteBox>


### PR DESCRIPTION
Fixes #12

References:
- [cryptolib/MasterkeyFileAccess.java#L198](https://github.com/cryptomator/cryptolib/blob/fcbd83eb1c02a0e01a06ba63963f416f376fb309/src/main/java/org/cryptomator/cryptolib/common/MasterkeyFileAccess.java#L198)
- [cryptolib-swift/MasterkeyFile.swift#L167-L169](https://github.com/cryptomator/cryptolib-swift/blob/d4e8f6db2b0053eb60cddb0829e4bf963082bb80/Sources/CryptomatorCryptoLib/MasterkeyFile.swift#L167-L169)