### PR TITLE
Update serial numbers for Windows artifacts through v1.19.1

### DIFF
--- a/docs/security/verify-installers.md
+++ b/docs/security/verify-installers.md
@@ -26,18 +26,23 @@ If shown, you can ignore the following warning:
 
 `gpg: WARNING: This key is not certified with a trusted signature!`
 
-## Windows (exe) {#windows}
+## Windows (exe, msi) {#windows}
 
 Our Windows installers are signed using a code signing certificate. You can verify the signature in five simple steps:
 
 <Image src="/img/security/verify-win-installer.png" srcset=" /img/security/verify-win-installer 1x, /img/security/verify-win-installer@2x.png 2x" alt="How to check the code signing certificate on Windows" width="1316" height="767" />
 
 1. Right click on the file and click on Properties.
-2. Select the Digital Signatures tab: It should show a signature by `Skymatic GmbH`.
-3. Click on Details.
+2. Select the Digital Signatures tab: It should show one or more signatures by `Skymatic GmbH` under Embedded Signatures.
+   - For releases since 1.17.1, the `exe` release artifact will have two signatures, and the `msi` release artifact will have one signature.
+3. Click on the first signature, and then click Details.
 4. Click on View Certificates.
-5. Click on Details. The serial number of our certificate should be:
-   - For releases since July 14, 2022: `d77e4f8b938f56ae265cd08e9193490c`
+5. Click the Details tab. The serial number of our certificate should be:
+   - For release version 1.19.1: `33000852bd6c3a151ff92180ee0000000852bd`
+   - For release version 1.19.0: `3300083c47651e1daeb99b00eb000000083c47`
+   - For release version 1.18.1: `330007d28ad57305892a81cac600000007d28a`
+   - For release version 1.18.0: `3300052c3561155e2baf361702000000052c35`
+   - For releases since July 14, 2022 to July 8, 2025 (version 1.17.1): `d77e4f8b938f56ae265cd08e9193490c`
    - For releases from July 3, 2019 to July 3, 2022: `63c45bff1a148d60ed2994d3a2639034`
 
 ## macOS (app) {#macos}


### PR DESCRIPTION
As the signing certificates for Windows artifacts have changed starting with version 1.18.0, also update the documented expected serial numbers for versions 1.18.0 through 1.19.1.