### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Verify lockfile has no non-registry sources
         run: scripts/check-lockfile.sh
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -29,7 +29,7 @@ jobs:
       - name: Build production
         run: pnpm run build
       - name: Upload Prod Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           name: prod-site
           path: './build'
@@ -40,7 +40,7 @@ jobs:
       - name: Add robots.txt for staging
         run: 'echo -e "User-agent: *\nDisallow: /" > build/robots.txt'
       - name: Upload Staging artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: staging-site
           path: './build'
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
           artifact_name: prod-site
     environment:
@@ -72,12 +72,12 @@ jobs:
     needs: [build]
     steps:
       - name: Download build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: staging-site
           path: ./public
       - name: Deploy to Staging Repository
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           personal_token: ${{ secrets.CRYPTOBOT_DEPLOY_STAGING_DOCS }}
           external_repository: cryptomator/docs-staging


### PR DESCRIPTION
  * actions/checkout from v4.3.1 to v6.0.2
  * actions/configure-pages from v5.0.0 to v6.0.0
  * pnpm/action-setup from v4.3.0 to v6.0.5
  * actions/setup-node from v4.4.0 to v6.4.0
  * actions/upload-pages-artifact from v3.0.1 to v5.0.0
  * actions/upload-artifact from v4.6.2 to v7.0.1
  * actions/deploy-pages from v4.0.5 to v5.0.0
  * actions/download-artifact from v4.3.0 to v8.0.1
  * peaceiris/actions-gh-pages from v3.9.3 to v4.0.0

Note: Updates do not contain any applicable improvements/changes